### PR TITLE
fixes St13runtime_error at launch

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -234,7 +234,7 @@ CDB::CDB(const char *pszFile, const char* pszMode) :
     pdb(NULL), activeTxn(NULL)
 {
     int ret;
-    if (pszFile == NULL)
+    if (pszFile == NULL || pszFile[0] == '\0')
         return;
 
     fReadOnly = (!strchr(pszMode, '+') && !strchr(pszMode, 'w'));


### PR DESCRIPTION
EXCEPTION: St13runtime_error  
CDB() : can't open database file , error 21
